### PR TITLE
Normalize auth email handling and display names

### DIFF
--- a/docs/potential-bugs.md
+++ b/docs/potential-bugs.md
@@ -1,0 +1,10 @@
+# Potential Bugs Identified
+
+## 1. Invalid Exposed package imports
+Several Kotlin files import classes from the `org.jetbrains.exposed.v1` namespace, for example `DatabaseFactory`, `User`, and `UserRepository`. The Exposed ORM artifacts published in `build.gradle.kts` (`exposed-core`, `exposed-dao`, `exposed-jdbc`, etc.) expose their APIs under `org.jetbrains.exposed.sql` (and related) packages. Attempting to compile with the `.v1` packages results in unresolved references and a build failure. The imports should be switched back to the canonical Exposed packages.
+
+## 2. Registration stores untrimmed e-mail addresses
+`AuthService.register` writes whatever string the HTTP layer passes in to the database without trimming it, while `AuthRoutes.login` trims the submitted e-mail before looking it up. This asymmetry means that if someone signs up with leading/trailing whitespace in their address, the stored value keeps the whitespace but login will query with the trimmed address and fail to find the user.
+
+## 3. `display_name` migration leaves old rows null
+Migration `V2__add_display_name_column.sql` adds the `display_name` column without a default value or backfill, so existing `users` rows will have `NULL` in that column. The Exposed model marks `Users.displayName` as a non-null `varchar`, so reading an older row will fail at runtime. The migration should either backfill a value or declare the column `NOT NULL DEFAULT ''` (and optionally update), or the model should allow nulls until the data is cleaned up.

--- a/server/src/main/kotlin/features/auth/AuthService.kt
+++ b/server/src/main/kotlin/features/auth/AuthService.kt
@@ -11,12 +11,15 @@ class AuthService(
         displayName: String,
         password: String,
     ): Result<UserSession> {
-        if (userRepository.findByEmail(email) != null) {
+        val normalizedEmail = email.trim()
+        val normalizedDisplayName = displayName.trim()
+
+        if (userRepository.findByEmail(normalizedEmail) != null) {
             return Result.failure(IllegalStateException("email_in_use"))
         }
 
         val hash = passwordHasher.hash(password)
-        val user = userRepository.create(email, displayName, hash)
+        val user = userRepository.create(normalizedEmail, normalizedDisplayName, hash)
         return Result.success(UserSession(user.id.value.toString(), user.email))
     }
 
@@ -24,8 +27,10 @@ class AuthService(
         email: String,
         password: String,
     ): Result<UserSession> {
+        val normalizedEmail = email.trim()
+
         val user =
-            userRepository.findByEmail(email)
+            userRepository.findByEmail(normalizedEmail)
                 ?: return Result.failure(IllegalArgumentException("invalid_credentials"))
         if (!user.isActive) return Result.failure(IllegalStateException("inactive_user"))
         if (!passwordHasher.verify(password, user.password)) {

--- a/server/src/main/resources/db/migration/V3__backfill_display_name.sql
+++ b/server/src/main/resources/db/migration/V3__backfill_display_name.sql
@@ -1,0 +1,9 @@
+ALTER TABLE users
+    ALTER COLUMN display_name SET DEFAULT '';
+
+UPDATE users
+SET display_name = ''
+WHERE display_name IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN display_name SET NOT NULL;


### PR DESCRIPTION
## Summary
- trim registration and login email inputs before querying or persisting users
- normalize display names during registration
- backfill existing rows and enforce a default for the display_name column to prevent null values

## Testing
- ./gradlew :server:test

------
https://chatgpt.com/codex/tasks/task_e_68e5243583c08330bb04d7fc4a50c04f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Normalize email inputs in registration and login to prevent whitespace-related login failures; all checks and creation now use trimmed values.
  - Backfill and enforce non-null display names by setting a default empty value and updating existing null entries.

- Documentation
  - Added a guide outlining three potential issues and recommended remedies (incorrect library imports, email trimming inconsistency, and display_name migration considerations).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->